### PR TITLE
CF-381 modify xsl to use proper tenant id for the catalog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <xmlsec.version>1.4.6</xmlsec.version>
         <surefire-plugin.version>2.17</surefire-plugin.version>
         <org.springframework.version>4.0.4.RELEASE</org.springframework.version>
-        <usage-schema.version>1.75.0</usage-schema.version>
+        <usage-schema.version>1.76.0</usage-schema.version>
         <rpm-maven-plugin.version>2.1-alpha-4</rpm-maven-plugin.version>
         <!-- this is required by rpm-maven-plugin -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/xsl/feedscatalog-resolve.xsl
+++ b/src/main/xsl/feedscatalog-resolve.xsl
@@ -40,7 +40,14 @@
     </xsl:copy>
   </xsl:template>
 
-  <xsl:param name="environment" select="document('/etc/feedscatalog/feedscatalog.xml')"/>
+  <xsl:param name="environment">
+    <xsl:choose>
+      <xsl:when test="doc-available('./src/test/resources/test_feedscatalog.xml')">
+          <xsl:copy-of select="document('./src/test/resources/test_feedscatalog.xml')"/>
+      </xsl:when>
+      <xsl:otherwise><xsl:copy-of select="document('/etc/feedscatalog/feedscatalog.xml')"/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:param>
 
   <xsl:template xmlns:app="http://www.w3.org/2007/app"
     match="/app:service/app:workspace/app:collection/@href">

--- a/src/main/xsl/wadl2SvcDoc.xsl
+++ b/src/main/xsl/wadl2SvcDoc.xsl
@@ -40,6 +40,9 @@
         <xsl:param name="base"></xsl:param>
         <xsl:variable name="path" select="@path"/>
         <xsl:variable name="isTenantFeed" select="contains( @type, 'wadl/feed.wadl#TenantAtomFeed') or contains( @type, 'TenantFeedsCatalog')"/>
+
+        <xsl:variable name="isFeedUsingNastId" select="matches( @id, 'files_events') or matches( @id, 'files_usagesummary_events')"/>
+
         <xsl:variable name="parent_path">
             <xsl:choose>
                 <xsl:when test="parent::wadl:resource/@path"><xsl:value-of select="parent::wadl:resource/@path"/></xsl:when>
@@ -55,7 +58,15 @@
                     <xsl:attribute name="href"></xsl:attribute>
                     <xsl:choose>
                         <xsl:when test="$generateTenantId = 'true'">
-                            <xsl:attribute name="href"><xsl:value-of select="concat($base,$parent_path,$path,'/${tenantId}')"/></xsl:attribute>
+                            <!-- add test here for event = files -->
+                            <xsl:choose>
+                                <xsl:when test="$isFeedUsingNastId">
+                                    <xsl:attribute name="href"><xsl:value-of select="concat($base,$parent_path,$path,'/${nastId}')"/></xsl:attribute>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:attribute name="href"><xsl:value-of select="concat($base,$parent_path,$path,'/${tenantId}')"/></xsl:attribute>
+                                </xsl:otherwise>
+                            </xsl:choose>
                         </xsl:when>
                         <xsl:otherwise>
                             <xsl:attribute name="href"><xsl:value-of select="concat($base,$parent_path,$path)"/></xsl:attribute>

--- a/src/main/xsl/wadl2SvcDoc.xsl
+++ b/src/main/xsl/wadl2SvcDoc.xsl
@@ -58,7 +58,6 @@
                     <xsl:attribute name="href"></xsl:attribute>
                     <xsl:choose>
                         <xsl:when test="$generateTenantId = 'true'">
-                            <!-- add test here for event = files -->
                             <xsl:choose>
                                 <xsl:when test="$isFeedUsingNastId">
                                     <xsl:attribute name="href"><xsl:value-of select="concat($base,$parent_path,$path,'/${nastId}')"/></xsl:attribute>

--- a/src/test/groovy/com/rackspace/feeds/feedscatalog/feedscatalogResolveTest.groovy
+++ b/src/test/groovy/com/rackspace/feeds/feedscatalog/feedscatalogResolveTest.groovy
@@ -1,0 +1,71 @@
+package com.rackspace.feeds.feedscatalog
+
+import com.rackspace.feeds.utils.BaseTest
+import spock.lang.Shared
+
+import javax.xml.transform.stream.StreamResult
+import javax.xml.transform.stream.StreamSource
+
+class feedscatalogResolveTest extends BaseTest {
+
+    @Shared xslt = "./src/main/xsl/feedscatalog-resolve.xsl"
+    @Shared String allfeeds_XmlString = new File('./src/test/resources/test_allfeeds.xml').text
+    @Shared String allfeeds_observer_XmlString = new File('./src/test/resources/test_allfeeds_observer.xml').text
+
+    def setupMoreSpec() {
+        System.setProperty("javax.xml.transform.TransformerFactory",
+                            "net.sf.saxon.TransformerFactoryImpl");
+    }
+
+    def "Generate all feeds catalog"() {
+        when:
+        def transformer = transformerFactory.newTransformer(new StreamSource(new FileReader(xslt)))
+        def output = new ByteArrayOutputStream()
+        transformer.setParameter("input-headers-uri", "./src/test/resources/repose-input-headers-uri.xml")
+        transformer.setParameter("input-query-uri", "./src/test/resources/repose-input-query-uri.xml")
+        transformer.setParameter("input-request-uri", "./src/test/resources/repose-input-request-uri.xml")
+
+        transformer.transform(new StreamSource(new StringReader(allfeeds_XmlString)), new StreamResult(output))
+
+        def result = output.toString()
+
+        then:
+        assert getStringValue(result, "/service/workspace[1]/title") == "backup_events"
+        assert getStringValue(result, "/service/workspace[1]/collection/@href").contains("/backup/events")
+
+        assert getStringValue(result, "/service/workspace[2]/title") == "bigdata_events"
+        assert getStringValue(result, "/service/workspace[2]/collection/@href").contains("/bigdata/events")
+
+        assert getStringValue(result, "/service/workspace[3]/title") == "files_events"
+        assert getStringValue(result, "/service/workspace[3]/collection/@href").contains("/files/events")
+
+        assert getStringValue(result, "/service/workspace[4]/title") == "files_usagesummary_events"
+        assert getStringValue(result, "/service/workspace[4]/collection/@href").contains("/usagesummary/files/events")
+    }
+
+    def "Generate feeds catalog with tenantId using feedscatalog-resolve.xsl"() {
+        when:
+        def transformer = transformerFactory.newTransformer(new StreamSource(new FileReader(xslt)))
+        def output = new ByteArrayOutputStream()
+        transformer.setParameter("input-headers-uri", "./src/test/resources/repose-input-headers-uri.xml")
+        transformer.setParameter("input-query-uri", "./src/test/resources/repose-input-query-uri.xml")
+        transformer.setParameter("input-request-uri", "./src/test/resources/repose-input-request-uri.xml")
+
+        transformer.transform(new StreamSource(new StringReader(allfeeds_observer_XmlString)), new StreamResult(output))
+
+        def result = output.toString()
+
+        then:
+        assert getStringValue(result, "/service/workspace[1]/title") == "backup_events"
+        assert getStringValue(result, "/service/workspace[1]/collection/@href").contains("/backup/events/1234567")
+
+        assert getStringValue(result, "/service/workspace[2]/title") == "bigdata_events"
+        assert getStringValue(result, "/service/workspace[2]/collection/@href").contains("/bigdata/events/1234567")
+
+        assert getStringValue(result, "/service/workspace[3]/title") == "files_events"
+        assert getStringValue(result, "/service/workspace[3]/collection/@href").contains("/files/events/MossoID_aaa1-bbb2-ccc3-ddd4-eee5")
+
+        assert getStringValue(result, "/service/workspace[4]/title") == "files_usagesummary_events"
+        assert getStringValue(result, "/service/workspace[4]/collection/@href").contains("/usagesummary/files/events/MossoID_aaa1-bbb2-ccc3-ddd4-eee5")
+    }
+}

--- a/src/test/groovy/com/rackspace/feeds/feedscatalog/feedscatalogResolveTest.groovy
+++ b/src/test/groovy/com/rackspace/feeds/feedscatalog/feedscatalogResolveTest.groovy
@@ -31,16 +31,16 @@ class feedscatalogResolveTest extends BaseTest {
 
         then:
         assert getStringValue(result, "/service/workspace[1]/title") == "backup_events"
-        assert getStringValue(result, "/service/workspace[1]/collection/@href").contains("/backup/events")
+        assert getStringValue(result, "/service/workspace[1]/collection/@href") == "https://test.atom.vip/backup/events"
 
         assert getStringValue(result, "/service/workspace[2]/title") == "bigdata_events"
-        assert getStringValue(result, "/service/workspace[2]/collection/@href").contains("/bigdata/events")
+        assert getStringValue(result, "/service/workspace[2]/collection/@href") == "https://test.atom.vip/bigdata/events"
 
         assert getStringValue(result, "/service/workspace[3]/title") == "files_events"
-        assert getStringValue(result, "/service/workspace[3]/collection/@href").contains("/files/events")
+        assert getStringValue(result, "/service/workspace[3]/collection/@href") == "https://test.atom.vip/files/events"
 
         assert getStringValue(result, "/service/workspace[4]/title") == "files_usagesummary_events"
-        assert getStringValue(result, "/service/workspace[4]/collection/@href").contains("/usagesummary/files/events")
+        assert getStringValue(result, "/service/workspace[4]/collection/@href") == "https://test.atom.vip/usagesummary/files/events"
     }
 
     def "Generate feeds catalog with tenantId using feedscatalog-resolve.xsl"() {
@@ -57,15 +57,15 @@ class feedscatalogResolveTest extends BaseTest {
 
         then:
         assert getStringValue(result, "/service/workspace[1]/title") == "backup_events"
-        assert getStringValue(result, "/service/workspace[1]/collection/@href").contains("/backup/events/1234567")
+        assert getStringValue(result, "/service/workspace[1]/collection/@href") == "https://test.atom.vip/backup/events/1234567"
 
         assert getStringValue(result, "/service/workspace[2]/title") == "bigdata_events"
-        assert getStringValue(result, "/service/workspace[2]/collection/@href").contains("/bigdata/events/1234567")
+        assert getStringValue(result, "/service/workspace[2]/collection/@href") == "https://test.atom.vip/bigdata/events/1234567"
 
         assert getStringValue(result, "/service/workspace[3]/title") == "files_events"
-        assert getStringValue(result, "/service/workspace[3]/collection/@href").contains("/files/events/MossoID_aaa1-bbb2-ccc3-ddd4-eee5")
+        assert getStringValue(result, "/service/workspace[3]/collection/@href") == "https://test.atom.vip/files/events/MossoID_aaa1-bbb2-ccc3-ddd4-eee5"
 
         assert getStringValue(result, "/service/workspace[4]/title") == "files_usagesummary_events"
-        assert getStringValue(result, "/service/workspace[4]/collection/@href").contains("/usagesummary/files/events/MossoID_aaa1-bbb2-ccc3-ddd4-eee5")
+        assert getStringValue(result, "/service/workspace[4]/collection/@href") == "https://test.atom.vip/usagesummary/files/events/MossoID_aaa1-bbb2-ccc3-ddd4-eee5"
     }
 }

--- a/src/test/resources/repose-input-headers-uri.xml
+++ b/src/test/resources/repose-input-headers-uri.xml
@@ -1,0 +1,43 @@
+<headers xmlns="http://openrepose.org/repose/httpx/v1.0">
+    <request>
+        <header quality="1.0" name="via" value="1.1 localhost:9090 (Repose/6.1.1.1)"/>
+        <header quality="1.0" name="x-forwarded-for" value="0:0:0:0:0:0:0:1"/>
+        <header quality="1.0" name="Host" value="localhost:9090"/>
+        <header quality="1.0" name="accept" value="application/atom+xml"/>
+        <header quality="1.0" name="x-tenant-id" value="1234567"/>
+        <header quality="1.0" name="x-tenant-id" value="MossoID_aaa1-bbb2-ccc3-ddd4-eee5"/>
+        <header quality="1.0" name="x-user-id" value="10213130"/>
+        <header quality="1.0" name="User-Agent" value="curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.16.2.3 Basic ECC zlib/1.2.3 libidn/1.18 libssh2/1.4.2"/>
+        <header quality="1.0" name="x-default-region" value="DFW"/>
+        <header quality="1.0" name="x-external-loc" value="localhost:9090"/>
+        <header quality="1.0" name="x-tenant-name" value="9999999"/>
+        <header quality="1.0" name="x-token-expires" value="Fri, 09 Jan 2099 23:23:21 GMT"/>
+        <header quality="0.2" name="x-pp-user" value="0:0:0:0:0:0:0:1"/>
+        <header quality="1.0" name="x-pp-user" value="testuser"/>
+        <header quality="1.0" name="x-roles" value="observer"/>
+        <header quality="1.0" name="x-roles" value="cloudfeeds:observer"/>
+        <header quality="1.0" name="x-roles" value="compute:default"/>
+        <header quality="1.0" name="x-roles" value="object-store:default"/>
+        <header quality="1.0" name="x-roles" value="identity:default"/>
+        <header quality="1.0" name="x-authorization" value="Proxy 5914283"/>
+        <header quality="1.0" name="x-user-name" value="testuser"/>
+        <header quality="1.0" name="X-Auth-Token" value="1000000000000000000000000000000a"/>
+        <header quality="0.2" name="x-pp-groups" value="IP_Standard"/>
+        <header quality="1.0" name="x-pp-groups" value="3814"/>
+        <header quality="1.0" name="x-pp-groups" value="observer"/>
+        <header quality="1.0" name="x-pp-groups" value="cloudfeeds:observer"/>
+        <header quality="1.0" name="x-pp-groups" value="compute:default"/>
+        <header quality="1.0" name="x-pp-groups" value="object-store:default"/>
+        <header quality="1.0" name="x-pp-groups" value="identity:default"/>
+    </request>
+    <response>
+        <header quality="1.0" name="Content-Language" value="en-US"/>
+        <header quality="1.0" name="ETag" value="WWWWWW-11111"/>
+        <header quality="1.0" name="Date" value="Fri, 09 Jan 2015 15:46:43 GMT"/>
+        <header quality="1.0" name="Content-Length" value="8198"/>
+        <header quality="1.0" name="Last-Modified" value="Wed, 07 Jan 2015 23:14:31 GMT"/>
+        <header quality="1.0" name="Via" value="1.1 Repose (Repose/6.1.1.1)"/>
+        <header quality="1.0" name="Accept-Ranges" value="bytes"/>
+        <header quality="1.0" name="Content-Type" value="application/xml;charset=UTF-8"/>
+    </response>
+</headers>

--- a/src/test/resources/repose-input-query-uri.xml
+++ b/src/test/resources/repose-input-query-uri.xml
@@ -1,0 +1,1 @@
+<parameters xmlns="http://openrepose.org/repose/httpx/v1.0"/>

--- a/src/test/resources/repose-input-request-uri.xml
+++ b/src/test/resources/repose-input-request-uri.xml
@@ -1,0 +1,23 @@
+<request-information xmlns="http://openrepose.org/repose/httpx/v1.0">
+    <uri>/feedscatalog/catalog/1234567</uri>
+    <url>http://0.0.0.0:9090/feedscatalog/catalog/1234567</url>
+    <informational>
+        <auth-type/>
+        <context-path/>
+        <local-addr>0:0:0:0:0:0:0:1</local-addr>
+        <local-name>0:0:0:0:0:0:0:1</local-name>
+        <local-port>9090</local-port>
+        <request-method>GET</request-method>
+        <path-info>/feedscatalog/catalog/5914283</path-info>
+        <path-translated/>
+        <protocol>HTTP/1.1</protocol>
+        <remote-addr>0:0:0:0:0:0:0:1</remote-addr>
+        <remote-host>0:0:0:0:0:0:0:1</remote-host>
+        <remote-port>37362</remote-port>
+        <remote-user/>
+        <session-id/>
+        <scheme>http</scheme>
+        <server-name>localhost</server-name>
+        <server-port>9090</server-port>
+        <servlet-path/></informational>
+</request-information>

--- a/src/test/resources/test_allfeeds.xml
+++ b/src/test/resources/test_allfeeds.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<service xmlns="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom">
+    <workspace>
+        <atom:title>backup_events</atom:title>
+        <collection href="http://localhost/backup/events">
+            <atom:title>backup_events</atom:title>
+        </collection>
+    </workspace>
+    <workspace>
+        <atom:title>bigdata_events</atom:title>
+        <collection href="http://localhost/bigdata/events">
+            <atom:title>bigdata_events</atom:title>
+        </collection>
+    </workspace>
+    <workspace>
+        <atom:title>files_events</atom:title>
+        <collection href="http://localhost/files/events">
+            <atom:title>files_events</atom:title>
+        </collection>
+    </workspace>
+    <workspace>
+        <atom:title>files_usagesummary_events</atom:title>
+        <collection href="http://localhost/usagesummary/files/events">
+            <atom:title>files_usagesummary_events</atom:title>
+        </collection>
+    </workspace>
+</service>

--- a/src/test/resources/test_allfeeds_observer.xml
+++ b/src/test/resources/test_allfeeds_observer.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<service xmlns="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom">
+    <workspace>
+        <atom:title>backup_events</atom:title>
+        <collection href="http://localhost/backup/events/${tenantId}">
+            <atom:title>backup_events</atom:title>
+        </collection>
+    </workspace>
+    <workspace>
+        <atom:title>bigdata_events</atom:title>
+        <collection href="http://localhost/bigdata/events/${tenantId}">
+            <atom:title>bigdata_events</atom:title>
+        </collection>
+    </workspace>
+    <workspace>
+        <atom:title>files_events</atom:title>
+        <collection href="http://localhost/files/events/${nastId}">
+            <atom:title>files_events</atom:title>
+        </collection>
+    </workspace>
+    <workspace>
+        <atom:title>files_usagesummary_events</atom:title>
+        <collection href="http://localhost/usagesummary/files/events/${nastId}">
+            <atom:title>files_usagesummary_events</atom:title>
+        </collection>
+    </workspace>
+</service>

--- a/src/test/resources/test_feedscatalog.xml
+++ b/src/test/resources/test_feedscatalog.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This file needs to go to /etc/feedscatalog directory.
+-->
+<environment>
+    <region>DFW</region>
+    <vipURL>https://test.atom.vip</vipURL>
+    <externalVipURL>https://test.feeds.vip</externalVipURL>
+</environment>


### PR DESCRIPTION
- modify wadl2SvcDoc.xsl to transform url to include nastId for files events
and tenantId (mossoId) for non-files events

- modify feedscatalog-resolve to pull tenantIds from header x-tenant-id instead of the uri
the default tenantId (mosso) being the shorter one,
and the NAST ID being the longer one.

- add tests for feedscatalog-resolve.xsl
