### PR TITLE
CF-303: set filterOnGenericJsonMediaType to true for Xml2JsonFilter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <org.springframework.version>4.0.4.RELEASE</org.springframework.version>
         <usage-schema.version>1.79.0</usage-schema.version>
         <rpm-maven-plugin.version>2.1-alpha-4</rpm-maven-plugin.version>
+        <cloudfeeds.atomhopper.version>1.9.0</cloudfeeds.atomhopper.version>
         <!-- this is required by rpm-maven-plugin -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -83,13 +84,13 @@
         <dependency>
             <groupId>com.rackspace.feeds.filters</groupId>
             <artifactId>filter-utils</artifactId>
-            <version>1.8.0</version>
+            <version>${cloudfeeds.atomhopper.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>com.rackspace.feeds.filters</groupId>
             <artifactId>json-filter</artifactId>
-            <version>1.9.0</version>
+            <version>${cloudfeeds.atomhopper.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.rackspace.feeds.filters</groupId>
             <artifactId>json-filter</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.0</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -44,6 +44,10 @@
             <param-name>xsltFile</param-name>
             <param-value>/etc/cloudfeeds/translation/xml2json-feeds.xsl</param-value>
         </init-param>
+        <init-param>
+            <param-name>filterOnGenericJsonMediaType</param-name>
+            <param-value>true</param-value>
+        </init-param>
     </filter>
 
     <filter>


### PR DESCRIPTION
This is configuration changes to turn on the Xml2JsonFilter used by Cloud Feeds Catalog to trigger on the xml2json translation if the Accept: application/json header is sent.

** Please don't merge** in yet, until I cut the 1.9.0 release of cloudfeeds-atomhopper. The PR build for this may fail as I don't have 1.9.0 version yet. 