### PR TITLE
CF-477: add Preferences Svc endpoints to catalog

### DIFF
--- a/src/main/resources/feedscatalog-resolve-host.xsl
+++ b/src/main/resources/feedscatalog-resolve-host.xsl
@@ -53,4 +53,25 @@
         <xsl:attribute name="href"><xsl:value-of select="$newUrl"/></xsl:attribute>
 
     </xsl:template>
+
+    <xsl:template xmlns:app="http://www.w3.org/2007/app" 
+                  xmlns:atom="http://www.w3.org/2005/Atom"
+                  match="/app:service/app:workspace/atom:link[@rel='archive-preferences']/@href">
+
+        <xsl:variable name="prefsSvcVip">
+            <xsl:value-of select="$environment/environment/prefsSvcVipURL/text()"/>
+        </xsl:variable>
+
+        <xsl:variable name="urlWithPrefsSvc">
+            <xsl:value-of select="replace(current(), '\$\{prefsSvcVipUrl\}', $prefsSvcVip)"/>
+        </xsl:variable>
+
+        <xsl:variable name="urlWithTenantId">
+            <xsl:value-of select="replace($urlWithPrefsSvc, '\$\{tenantId\}', $tenantId)"/>
+        </xsl:variable>
+
+        <xsl:attribute name="href"><xsl:value-of select="$urlWithTenantId"/></xsl:attribute>
+
+    </xsl:template>
+
 </xsl:stylesheet>

--- a/src/main/xsl/wadl2SvcDoc.xsl
+++ b/src/main/xsl/wadl2SvcDoc.xsl
@@ -25,6 +25,16 @@
             <xsl:apply-templates select="wadl:resource" mode="expand">
                 <xsl:with-param name="base" select="@base"/>
             </xsl:apply-templates>
+
+            <!-- hard code Preferences Service endpoint -->
+            <workspace>
+                <atom:title>Feeds Archiving Preferences Service endpoints</atom:title>
+                <atom:link>
+                    <xsl:attribute name="href"><xsl:value-of select="'${prefsSvcVipUrl}/archive/${tenantId}'"/></xsl:attribute>
+                    <xsl:attribute name="rel"><xsl:value-of select="'archive-preferences'"/></xsl:attribute>
+                </atom:link>
+            </workspace>
+
             <xsl:comment>
                 <xsl:text> Generated from schema version </xsl:text>
                 <xsl:value-of select="$usageSchemaVers"/>

--- a/src/test/groovy/com/rackspace/feeds/feedscatalog/Wadl2SvcDocTest.groovy
+++ b/src/test/groovy/com/rackspace/feeds/feedscatalog/Wadl2SvcDocTest.groovy
@@ -86,4 +86,18 @@ class Wadl2SvcDocTest extends BaseTest {
         assert getStringValue(result, "/service/workspace[4]/collection/@href") == "http://myhost/nested/service3/path"
 
     }
+
+    def "Generated Svc Doc should have Prefs Svc endpoint"() {
+        when:
+        def transformer = transformerFactory.newTransformer(new StreamSource(new FileReader(xslt)))
+        def output = new ByteArrayOutputStream()
+        transformer.setParameter("generateTenantId", "false")
+        transformer.setParameter("usageSchemaVers", "1.20")
+        transformer.transform(new StreamSource(new StringReader(wadlWithNestedResource)), new StreamResult(output))
+
+        def result = output.toString()
+
+        then:
+        assert getStringValue(result, "/service/workspace[last()]/link[@rel='archive-preferences']/@href") == "\${prefsSvcVipUrl}/archive/\${tenantId}"
+    }
 }

--- a/src/test/groovy/com/rackspace/feeds/feedscatalog/feedscatalogResolveTest.groovy
+++ b/src/test/groovy/com/rackspace/feeds/feedscatalog/feedscatalogResolveTest.groovy
@@ -6,7 +6,7 @@ import spock.lang.Shared
 import javax.xml.transform.stream.StreamResult
 import javax.xml.transform.stream.StreamSource
 
-class feedscatalogResolveTest extends BaseTest {
+class FeedscatalogResolveTest extends BaseTest {
 
     @Shared xslt = "./src/main/resources/feedscatalog-resolve-host.xsl"
     @Shared String allfeeds_XmlString = new File('./src/test/resources/test_allfeeds.xml').text
@@ -91,6 +91,8 @@ class feedscatalogResolveTest extends BaseTest {
 
         assert getStringValue(result, "/service/workspace[4]/title") == "files_usagesummary_events"
         assert getStringValue(result, "/service/workspace[4]/collection/@href") == "https://internal.atom.vip/usagesummary/files/events/" + NAST_ID
+
+        assert getStringValue(result, "/service/workspace[5]/link[@rel='archive-preferences']/@href") == "https://test.preferences.feeds.rackspacecloud.com/archive/" + TENANT_ID
     }
 
     def "Should change all urls to externalVip with tenantIds from the params, when x-external-loc is present"() {
@@ -118,5 +120,7 @@ class feedscatalogResolveTest extends BaseTest {
 
         assert getStringValue(result, "/service/workspace[4]/title") == "files_usagesummary_events"
         assert getStringValue(result, "/service/workspace[4]/collection/@href") == "https://external.feeds.vip/usagesummary/files/events/" + NAST_ID
+
+        assert getStringValue(result, "/service/workspace[5]/link[@rel='archive-preferences']/@href") == "https://test.preferences.feeds.rackspacecloud.com/archive/" + TENANT_ID
     }
 }

--- a/src/test/resources/test_allfeeds.xml
+++ b/src/test/resources/test_allfeeds.xml
@@ -24,4 +24,8 @@
             <atom:title>files_usagesummary_events</atom:title>
         </collection>
     </workspace>
+    <workspace>
+        <atom:title>Cloud Feeds Preferences Service</atom:title>
+        <atom:link href="${prefsSvcVipUrl}/archive/${tenantId}" rel="archive-preferences"/>
+    </workspace>
 </service>

--- a/src/test/resources/test_allfeeds_observer.xml
+++ b/src/test/resources/test_allfeeds_observer.xml
@@ -24,4 +24,8 @@
             <atom:title>files_usagesummary_events</atom:title>
         </collection>
     </workspace>
+    <workspace>
+        <atom:title>Cloud Feeds Preferences Service</atom:title>
+        <atom:link href="${prefsSvcVipUrl}/archive/${tenantId}" rel="archive-preferences"/>
+    </workspace>
 </service>

--- a/src/test/resources/test_feedscatalog.xml
+++ b/src/test/resources/test_feedscatalog.xml
@@ -6,4 +6,5 @@
     <region>DFW</region>
     <vipURL>https://internal.atom.vip</vipURL>
     <externalVipURL>https://external.feeds.vip</externalVipURL>
+    <prefsSvcVipURL>https://test.preferences.feeds.rackspacecloud.com</prefsSvcVipURL>
 </environment>


### PR DESCRIPTION
Changes to add the Preferences Svc endpoints to Feeds Catalog's Service document.