### PR TITLE
Release 1.135.0 hotfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rackspace.feeds</groupId>
     <artifactId>feedscatalog</artifactId>
-    <version>1.135.2</version>
+    <version>1.136.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>Feeds Catalog</name>
@@ -13,7 +13,7 @@
 
     <scm>
         <connection>scm:git:ssh://git@github.com/rackerlabs/cloudfeeds-catalog.git</connection>
-      <tag>feedscatalog-1.135.2</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rackspace.feeds</groupId>
     <artifactId>feedscatalog</artifactId>
-    <version>1.135.0-SNAPSHOT</version>
+    <version>1.135.1</version>
     <packaging>war</packaging>
 
     <name>Feeds Catalog</name>
@@ -13,7 +13,8 @@
 
     <scm>
         <connection>scm:git:ssh://git@github.com/rackerlabs/cloudfeeds-catalog.git</connection>
-    </scm>
+      <tag>feedscatalog-1.135.1</tag>
+  </scm>
 
     <repositories>
         <repository>
@@ -48,7 +49,7 @@
         <xmlsec.version>1.4.6</xmlsec.version>
         <surefire-plugin.version>2.17</surefire-plugin.version>
         <org.springframework.version>4.0.4.RELEASE</org.springframework.version>
-        <usage-schema.version>1.134.1</usage-schema.version>
+        <usage-schema.version>1.135.1</usage-schema.version>
         <rpm-maven-plugin.version>2.1-alpha-4</rpm-maven-plugin.version>
         <cloudfeeds.atomhopper.version>1.9.0</cloudfeeds.atomhopper.version>
         <!-- this is required by rpm-maven-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -480,6 +480,8 @@
                         <configuration>
                             <copyright>Apache License, Version 2.0</copyright>
                             <group>Applications/Communications</group>
+                            <needarch>noarch</needarch>
+                            <targetOS>linux</targetOS>
                             <packager>Rackspace - Cloud Integration Team</packager>
                             <description>Feeds Catalog</description>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rackspace.feeds</groupId>
     <artifactId>feedscatalog</artifactId>
-    <version>1.136.0-SNAPSHOT</version>
+    <version>1.135.2</version>
     <packaging>war</packaging>
 
     <name>Feeds Catalog</name>
@@ -13,7 +13,7 @@
 
     <scm>
         <connection>scm:git:ssh://git@github.com/rackerlabs/cloudfeeds-catalog.git</connection>
-      <tag>HEAD</tag>
+      <tag>feedscatalog-1.135.2</tag>
   </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rackspace.feeds</groupId>
     <artifactId>feedscatalog</artifactId>
-    <version>1.135.1</version>
+    <version>1.136.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>Feeds Catalog</name>
@@ -13,7 +13,7 @@
 
     <scm>
         <connection>scm:git:ssh://git@github.com/rackerlabs/cloudfeeds-catalog.git</connection>
-      <tag>feedscatalog-1.135.1</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <repositories>


### PR DESCRIPTION
# Code Under Test

A configuration element has been added to ensure that the RPM generation targets a Linux system allowing for builds on non-Linux systems.

## Checking configuration

The RPMs built with this configuration are currently deployed to test verifying their functionality. One can run a maven release dry run to confirm (most) functionality with the following command:

```bash
mvn -up -P build-app-rpm -Dresume=false release:prepare release:perform -DdryRun=true
```

## Additional Info

Problem Identified: [Slack Thread](https://rackspace.slack.com/archives/G7JDPGT24/p1594226907019500)
Plugin Documentation: [RPM Maven Plugin](https://www.mojohaus.org/rpm-maven-plugin/ident-params.html)
Successful RPM Installation: [Slack Thread](https://rackspace.slack.com/archives/G7JDPGT24/p1594397005020000)