### PR TITLE
Fix for vulnerability issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <mockito.version>1.9.5</mockito.version>
         <xmlsec.version>1.4.6</xmlsec.version>
         <surefire-plugin.version>2.17</surefire-plugin.version>
-        <org.springframework.version>4.0.4.RELEASE</org.springframework.version>
+        <org.springframework.version>5.2.23.RELEASE</org.springframework.version>
         <usage-schema.version>1.138.6</usage-schema.version>
         <rpm-maven-plugin.version>2.1-alpha-4</rpm-maven-plugin.version>
         <cloudfeeds.atomhopper.version>1.9.0</cloudfeeds.atomhopper.version>
@@ -95,9 +95,9 @@
             <type>jar</type>
         </dependency>
         <dependency>
-             <groupId>log4j</groupId>
-             <artifactId>log4j</artifactId>
-             <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.1</version>
         </dependency>
         <dependency> 
             <groupId>org.springframework</groupId>

--- a/src/main/java/com/rackspace/feeds/feedscatalog/ResolveHostFilter.java
+++ b/src/main/java/com/rackspace/feeds/feedscatalog/ResolveHostFilter.java
@@ -79,6 +79,7 @@ public class ResolveHostFilter implements Filter {
                 // set transformed content to response
                 String newResponseContent = outputStream.toString();
                 httpServletResponse.setContentLength(newResponseContent.length());
+                httpServletResponse.addHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
                 httpServletResponse.getWriter().write(newResponseContent);
             }
             catch (Exception e) {

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="2.5" 
-         xmlns="http://java.sun.com/xml/ns/javaee" 
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+<web-app version="3.0"
+        xmlns="http://java.sun.com/xml/ns/javaee"
+	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+
+          <session-config>
+            <session-timeout>30</session-timeout>
+            <cookie-config>
+                <http-only>true</http-only>
+                <secure>true</secure>
+            </cookie-config>
+        </session-config>
+
+    
 
     <display-name>Feeds Catalog</display-name>
     <description>Servlet that serves up static feeds catalog files</description>


### PR DESCRIPTION
### Changes done as part of this PR:

1. Changed the spring framework version in [POM file](https://github.com/rackerlabs/cloudfeeds-catalog/compare/master...CF-3485-Vulnerability-Issues#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8)
2. Log 4j version in [POM file](https://github.com/rackerlabs/cloudfeeds-catalog/compare/master...CF-3485-Vulnerability-Issues#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8)
3. Web App version in [web.xml](https://github.com/rackerlabs/cloudfeeds-catalog/compare/master...CF-3485-Vulnerability-Issues#diff-f1c1b2e33984786db489cb4229fb7610cabae6dc83df075488c9e1236a91268c)

### NOTE
1. The abovementioned changes can be tested on AWS by changing the war versions for **standard usage schema** and **cloudfeeds atomhopper.** 
2. Some trivy and checkmark issues are still coming in catalog modules from standard usage schema and cloudfeeds atomhopper internal dependency. Such issues are resolved in each module.
